### PR TITLE
Cog Generator

### DIFF
--- a/grace/exceptions.py
+++ b/grace/exceptions.py
@@ -19,6 +19,11 @@ class GeneratorError(GraceError):
     pass
 
 
+class NoTemplateError(GeneratorError):
+    """Exception raised when no template is found for a generator."""
+    pass
+
+
 class ValidationError(GeneratorError):
     """Exception raised for validation errors inside a generator."""
     pass

--- a/grace/generator.py
+++ b/grace/generator.py
@@ -25,7 +25,7 @@ def generator() -> Generator:
 from click import Command, Group
 from pathlib import Path
 from grace.importer import import_package_modules
-from grace.exceptions import GeneratorError, ValidationError
+from grace.exceptions import GeneratorError, ValidationError, NoTemplateError
 from cookiecutter.main import cookiecutter
 from jinja2 import Environment, PackageLoader, Template
 

--- a/grace/generator.py
+++ b/grace/generator.py
@@ -1,8 +1,33 @@
+"""This module provides a base implementation for a generator command,
+which simplifies the creation of templates using Cookiecutter. It also provides
+utilities for registering multiple generators to a command group dynamically.
+
+
+Usage:
+
+```python
+from grace.generator import Generator
+
+
+class MyGenerator(Generator):
+    NAME = 'my_generator'
+
+    def generate(self, *args, **kwargs):
+        # Implement the generate method here
+        ...
+
+
+def generator() -> Generator:
+    return MyGenerator()
+```
+
+"""
 from click import Command, Group
 from pathlib import Path
 from grace.importer import import_package_modules
-from cookiecutter.main import cookiecutter
 from grace.exceptions import GeneratorError, ValidationError
+from cookiecutter.main import cookiecutter
+from jinja2 import Environment, PackageLoader, Template
 
 
 def register_generators(command_group: Group):
@@ -20,11 +45,29 @@ def register_generators(command_group: Group):
         command_group.add_command(module.generator())
 
 
-class Generator(Command):
-    """Base class for a generator command.
+def _camel_case_to_space(value: str) -> str:
+    """Jinja2 filter to converts a camel case string to a space separated string.
 
-    This class provides a base implementation for a generator command that uses 
-    Cookiecutter to generate a project template.
+    :param value: The camel case string to convert.
+    :type value: str
+
+    :return: The space separated string.
+    :rtype: str
+    """
+    import re
+    return re.sub(r"(?<=[a-z])([A-Z])", r" \1", value)
+
+
+class Generator(Command):
+    """Base class for implementing a generator command.
+
+    This class provides a foundation for defining generator commands that use
+    Cookiecutter to generate project templates. It includes methods for template
+    generation, validation, and argument handling.
+
+    Attributes:
+    - `NAME`: The name of the generator command (must be defined by subclasses).
+    - `OPTIONS`: A dictionary of additional Click options for the command.
     """
     NAME: str = None
     OPTIONS: dict = {
@@ -32,6 +75,11 @@ class Generator(Command):
     }
 
     def __init__(self):
+        """Ensures that the `NAME` attribute is defined by the subclass.
+        Registers the command with Click using the specified name and options.
+
+        :raises GeneratorError: If the `NAME` attribute is not defined.
+        """
         if not self.NAME:
             raise GeneratorError("Generator name must be defined.")
 
@@ -60,14 +108,50 @@ class Generator(Command):
         """Validates the arguments passed to the command."""
         return True
 
-    def generate_template(self, template: str, values: dict[str, any] = {}):
+    def generate_template(self, template_dir: str, variables: dict[str, any] = {}):
         """Generates a template using Cookiecutter.
 
-        :param template: The name of the template to generate.
-        :type template: str
+        :param template_dir: The name of the template to generate.
+        :type template_dir: str
 
-        :param values: The values to pass to the template. (default is {})
-        :type values: dict[str, any]
+        :param variables: The variables to pass to the template. (default is {})
+        :type variables: dict[str, any]
         """
-        template_path = str(self.templates_path / template)
-        cookiecutter(template_path, extra_context=values, no_input=True)
+        template = str(self.templates_path / template_dir)
+        cookiecutter(template, extra_context=variables, no_input=True)
+
+    def generate_file(
+        self,
+        template_dir: str,
+        variables: dict[str, any] = {},
+        output_dir: str = ""
+    ):
+        """Generate a module using jinja2 template.
+
+        :param template_dir: The name of the template to generate.
+        :type template_dir: str
+
+        :param variables: The variables to pass to the template. (default is {})
+        :type variables: dict[str, any]
+
+        :param output_dir: The output directory for the generated template. (default is None)
+        :type output_dir: str
+        """
+        env = Environment(
+            loader=PackageLoader("grace", self.templates_path / template_dir),
+            extensions=['jinja2_strcase.StrcaseExtension']
+        )
+
+        env.filters['camel_case_to_space'] = _camel_case_to_space
+
+        if not env.list_templates():
+            raise NoTemplateError(f"No templates found in {template_dir}")
+
+        template_file = env.list_templates()[0]
+        template = env.get_template(template_file)
+
+        rendered_filename = env.from_string(template_file).render(variables)
+        rendered_content = template.render(variables)
+
+        with open(f"{output_dir}/{rendered_filename}", "w") as file:
+            file.write(rendered_content)

--- a/grace/generators/cog_generator.py
+++ b/grace/generators/cog_generator.py
@@ -1,0 +1,42 @@
+from grace.generator import Generator
+from re import match
+from logging import info
+from click.core import Argument
+
+
+class CogGenerator(Generator):
+    NAME: str = 'cog'
+    OPTIONS: dict = {
+        "params": [
+            Argument(["name"], type=str),
+            Argument(["description"], type=str, required=False, default="")
+        ],
+    }
+
+    def generate(self, name: str, description: str = ""):
+        info(f"Creating cog '{name}'")
+
+        self.generate_file(
+            self.NAME,
+            variables={
+                "cog_name": name,
+                "cog_description": description,
+            },
+            output_dir="bot/extensions"
+        )
+
+    def validate(self, name: str, **_kwargs) -> bool:
+        """Validate the cog name.
+
+        A valid project name must be 'PascalCase' and contain only
+        - letters [Aa - Zz]
+        - numbers [0-9]
+
+        Example:
+        - HelloWorld
+        """
+        return bool(match('([A-Z][a-z]*[0-9]*)+', name))
+
+
+def generator() -> Generator:
+    return CogGenerator()

--- a/grace/generators/cog_generator.py
+++ b/grace/generators/cog_generator.py
@@ -35,7 +35,7 @@ class CogGenerator(Generator):
         Example:
         - HelloWorld
         """
-        return bool(match('([A-Z][a-z]*[0-9]*)+', name))
+        return bool(match(r'^[A-Z][a-zA-Z0-9]*$', name))
 
 
 def generator() -> Generator:

--- a/grace/generators/templates/cog/{{ cog_name | to_snake }}_cog.py
+++ b/grace/generators/templates/cog/{{ cog_name | to_snake }}_cog.py
@@ -1,0 +1,11 @@
+from grace.bot import Bot
+from discord.ext.commands import Cog
+
+
+class {{ cog_name | to_camel }}Cog(Cog, name="{{ cog_name | camel_case_to_space }}"{{ ', description="{}"'.format(cog_description) if cog_description }}):
+	def __init__(self, bot: Bot):
+		self.bot: Bot = bot
+
+
+async def setup(bot: Bot):
+	await bot.add_cog({{ cog_name }}Cog(bot))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
 	"sqlalchemy-utils",
 	"alembic==1.8.1",
 	"cookiecutter",
+	"jinja2-strcase",
 	"mypy",
 	"pytest",
 	"flake8",

--- a/tests/generators/test_cog_generator.py
+++ b/tests/generators/test_cog_generator.py
@@ -1,0 +1,44 @@
+import pytest
+from unittest.mock import patch, mock_open
+from grace.generator import Generator
+from grace.generators.cog_generator import CogGenerator
+from pathlib import Path
+
+
+@pytest.fixture
+def generator():
+    return CogGenerator()
+
+
+def test_generate_cog(mocker, generator):
+    """Test if the generate method creates the correct template with a database."""
+    mock_generate_file = mocker.patch.object(Generator, 'generate_file')
+
+    name = "Example"
+    description = "This is an example cog."
+
+    generator.generate(name, description)
+
+    mock_generate_file.assert_called_once_with(
+        'cog', 
+        variables={
+            'cog_name': name,
+            'cog_description': description
+        },
+        output_dir="bot/extensions"
+    )
+
+
+
+def test_validate_valid_name(generator):
+    """Test if the validate method passes for a valid project name."""
+    valid_name = "CogExample"
+    assert generator.validate(valid_name) == True
+
+
+def test_validate_invalid_name(generator):
+    """Test if the validate method raises ValueError for name without a hyphen."""
+    assert generator.validate("cog-example") == False
+    assert generator.validate("cog_example") == False
+    assert generator.validate("Cog-Example") == False
+    assert generator.validate("Cog_Example") == False

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -28,7 +28,7 @@ def test_validate(generator):
 def test_generate_template(generator):
   """Test if the generator generate_template method calls cookiecutter with the correct arguments"""
   with patch('grace.generator.cookiecutter') as cookiecutter:
-    generator.generate_template('project', values={})
+    generator.generate_template('project', variables={})
     template_path = str(generator.templates_path / 'project')
     cookiecutter.assert_called_once_with(template_path, extra_context={}, no_input=True)
 


### PR DESCRIPTION
This PR introduces a generator for creating cogs, along with the necessary utilities to generate a single-file template. These utilities were added because Cookiecutter does not currently support this functionality. 

The generator for cogs serves as the first implementation of broader utilities that will be used for in future generators, such as for creating models, tests, migrations, seeds, etc. 

Usage:
```bash
grace generate cog [OPTIONS] NAME [DESCRIPTION]
```

Example:
```
grace generate cog Greeter "My greeter"
```