### PR TITLE
Database commands

### DIFF
--- a/grace/bot.py
+++ b/grace/bot.py
@@ -3,6 +3,7 @@ from discord import LoginFailure, Intents, ActivityType, Activity
 from discord.ext.commands import Bot as DiscordBot, when_mentioned_or
 from grace.application import Application, SectionProxy
 
+
 class Bot(DiscordBot):
     """This class is the bot core
 

--- a/grace/cli.py
+++ b/grace/cli.py
@@ -2,7 +2,7 @@ import discord
 
 from os import getpid, getcwd
 from sys import path
-from logging import info
+from logging import info, warning
 from click import group, argument, option, pass_context
 from grace.generator import register_generators
 
@@ -56,6 +56,38 @@ def run(environment=None, sync=None):
         print("Unable to find a Grace project in this directory.")
 
 
+@cli.group()
+def db():
+    pass
+
+
+# db group commands (create, drop, seed, reset)
+@db.command()
+def create():
+    if app.database_exists:
+        return warning("Database already exists")
+
+    app.create_database()
+    app.create_tables()
+
+
+@db.command()
+def drop():
+    if not app.database_exists:
+        return warning("Database does not exist")
+
+    app.drop_tables()
+    app.drop_database()
+
+
+@db.command()
+def seed():
+    if not app.database_exists:
+        return warning("Database does not exist")
+        
+    app.seed_database()
+
+
 def _loading_application(app, environment, command_sync):
     app.load(environment, command_sync=command_sync)
 
@@ -64,6 +96,7 @@ def _load_database(app):
     if not app.database_exists:
         app.create_database()
         app.create_tables()
+
 
 def _show_application_info(app):
     info(APP_INFO.format(
@@ -74,7 +107,3 @@ def _show_application_info(app):
         database=app.database_infos["database"],
         dialect=app.database_infos["dialect"],
     ))
-
-
-def main():
-    cli()

--- a/grace/config.py
+++ b/grace/config.py
@@ -80,20 +80,6 @@ class Config:
         self.read("config/environment.cfg")
 
     @property
-    def database_uri(self) -> Union[str, URL]:
-        if self.database.get("url"):
-            return self.database.get("url")
-
-        return URL.create(
-            self.database["adapter"],
-            self.database.get("user"),
-            self.database.get("password"),
-            self.database.get("host"),
-            self.database.getint("port"),
-            self.database.get("database", self.database_name)
-        )
-
-    @property
     def database(self) -> SectionProxy:
         return self.__config[f"database.{self.__environment}"]
 
@@ -108,6 +94,20 @@ class Config:
     @property
     def current_environment(self) -> Optional[str]:
         return self.__environment
+
+    @property
+    def database_uri(self) -> Union[str, URL]:
+        if self.database.get("url"):
+            return self.database.get("url")
+
+        return URL.create(
+            self.database.get("adapter"),
+            self.database.get("user"),
+            self.database.get("password"),
+            self.database.get("host"),
+            self.database.getint("port"),
+            self.database.get("database", self.database_name)
+        )
 
     @property
     def database_name(self) -> str:

--- a/grace/generators/templates/project/{{ cookiecutter.__project_slug }}/bot/__init__.py
+++ b/grace/generators/templates/project/{{ cookiecutter.__project_slug }}/bot/__init__.py
@@ -2,7 +2,4 @@ from grace.application import Application
 from bot.{{ cookiecutter.__project_slug }} import {{ cookiecutter.__project_class }}
 
 app = Application()
-
-
-def run():
-    {{ cookiecutter.__project_class }}(app).run()
+bot = {{ cookiecutter.__project_class }}(app)

--- a/grace/generators/templates/project/{{ cookiecutter.__project_slug }}/db/seed.py
+++ b/grace/generators/templates/project/{{ cookiecutter.__project_slug }}/db/seed.py
@@ -17,10 +17,9 @@ def seed_database():
     model.save()
 ```
 
-If you have many seeds or want a more structured approach to seeding,
-it is recommended to create a `db/seeds/` directory and organize your seeding
-scripts within that folder. You can then import your seeding modules into
-this script and call them as needed.
+If you have multiple seed file or prefer a structured approach, consider 
+creating a `db/seeds/` directory to organize your seeding scripts. 
+You can then import and execute these modules within this script as needed.
 """
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 "Source" = "https://github.com/Code-Society-Lab/grace-framework"
 
 [project.scripts]
-grace = "grace.cli:main"
+grace = "grace.cli:cli"
 
 [tool.setuptools]
 packages = ["grace"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 "Source" = "https://github.com/Code-Society-Lab/grace-framework"
 
 [project.scripts]
-grace = "grace.cli:cli"
+grace = "grace.cli:main"
 
 [tool.setuptools]
 packages = ["grace"]


### PR DESCRIPTION
This PR add the basic commands to handle database operations. Along the new commands, some major refactoring of `cli.py` have been done to more properly handle commands requiring the application and those who doesn't. 

Command added : 
- `grace db create` : Create the database and tables
- `grace db drop` : Drop the tables and database.
- `grace db seed` : Seed the database

All of those operation can take an optional `--environment` to perform them on different environment. (Ex. `grace db drop --environment development`  