### PR TITLE
Model generator

### DIFF
--- a/grace/cli.py
+++ b/grace/cli.py
@@ -5,6 +5,7 @@ from os import getpid, getcwd
 from logging import info, warning, critical
 from click import group, argument, option, pass_context, echo
 from grace.generator import register_generators
+from grace.database import up_migration, down_migration
 from textwrap import dedent
 
 
@@ -46,8 +47,8 @@ def new(ctx, name, database=True):
 def app_cli(ctx, environment):
     app = ctx.obj["app"]
 
-    register_generators(generate)
     app.load(environment)
+    register_generators(generate)
 
 
 @app_cli.group()
@@ -108,6 +109,30 @@ def seed(ctx):
 
     from db import seed
     seed.seed_database()
+
+
+# TODO: Add revision #
+@db.command()
+@pass_context
+def up(ctx):
+    app = ctx.obj["app"]
+
+    if not app.database_exists:
+        return warning("Database does not exist")
+
+    up_migration(app)
+
+
+# TODO: Add revision #
+@db.command()
+@pass_context
+def down(ctx):
+    app = ctx.obj["app"]
+
+    if not app.database_exists:
+        return warning("Database does not exist")
+
+    down_migration(app)
 
 
 def _load_database(app):

--- a/grace/cli.py
+++ b/grace/cli.py
@@ -111,28 +111,28 @@ def seed(ctx):
     seed.seed_database()
 
 
-# TODO: Add revision #
 @db.command()
+@argument("revision", default='head')
 @pass_context
-def up(ctx):
+def up(ctx, revision):
     app = ctx.obj["app"]
 
     if not app.database_exists:
         return warning("Database does not exist")
 
-    up_migration(app)
+    up_migration(app, revision)
 
 
-# TODO: Add revision #
 @db.command()
+@argument("revision", default='head')
 @pass_context
-def down(ctx):
+def down(ctx, revision):
     app = ctx.obj["app"]
 
     if not app.database_exists:
         return warning("Database does not exist")
 
-    down_migration(app)
+    down_migration(app, revision)
 
 
 def _load_database(app):

--- a/grace/config.py
+++ b/grace/config.py
@@ -101,7 +101,7 @@ class Config:
             return self.database.get("url")
 
         return URL.create(
-            self.database.get("adapter"),
+            self.database.get("adapter", "sqlite"),
             self.database.get("user"),
             self.database.get("password"),
             self.database.get("host"),
@@ -139,10 +139,7 @@ class Config:
     def set_environment(self, environment: str):
         """Set the environment for the configuration.
 
-        :param environment: The environment to set. (Production, Development, Test)
+        :param environment: The environment to set.
         :type environment: str
         """
-        if environment in ["production", "development", "test"]:
-            self.__environment = environment
-        else:
-            raise EnvironmentError("You need to pass a valid environment. [Production, Development, Test]")
+        self.__environment = environment

--- a/grace/database.py
+++ b/grace/database.py
@@ -1,0 +1,36 @@
+from alembic.config import Config
+from alembic.command import revision, upgrade, downgrade, show
+from alembic.util.exc import CommandError
+from logging import info, fatal
+
+from alembic.script import ScriptDirectory
+
+
+def generate_migration(app, message):
+    alembic_cfg = Config("alembic.ini")
+    alembic_cfg.config_ini_section = app.config.current_environment
+
+    try:
+        revision(
+            alembic_cfg,
+            message=message,
+            autogenerate=True,
+            sql=False,
+            head='base'
+        )
+    except CommandError as e:
+        fatal(f"Error creating migration: {e}")
+
+
+def up_migration(app, revision='head'):
+    alembic_cfg = Config("alembic.ini")
+    alembic_cfg.config_ini_section = app.config.current_environment
+
+    upgrade(alembic_cfg, revision=revision)
+
+
+def down_migration(app, revision='head'):
+    alembic_cfg = Config("alembic.ini")
+    alembic_cfg.config_ini_section = app.config.current_environment
+
+    upgrade(alembic_cfg, revision=revision)

--- a/grace/database.py
+++ b/grace/database.py
@@ -15,14 +15,15 @@ def generate_migration(app, message):
             alembic_cfg,
             message=message,
             autogenerate=True,
-            sql=False,
-            head='base'
+            sql=False
         )
     except CommandError as e:
         fatal(f"Error creating migration: {e}")
 
 
 def up_migration(app, revision='head'):
+    info(f"Upgrading revision {revision}")
+
     alembic_cfg = Config("alembic.ini")
     alembic_cfg.config_ini_section = app.config.current_environment
 
@@ -30,7 +31,9 @@ def up_migration(app, revision='head'):
 
 
 def down_migration(app, revision='head'):
+    info(f"Downgrading revision {revision}")
+
     alembic_cfg = Config("alembic.ini")
     alembic_cfg.config_ini_section = app.config.current_environment
 
-    upgrade(alembic_cfg, revision=revision)
+    downgrade(alembic_cfg, revision=revision)

--- a/grace/generator.py
+++ b/grace/generator.py
@@ -27,6 +27,7 @@ import inflect
 
 from click import Command, Group
 from pathlib import Path
+from grace.application import Application
 from grace.importer import import_package_modules
 from grace.exceptions import GeneratorError, ValidationError, NoTemplateError
 from cookiecutter.main import cookiecutter
@@ -84,6 +85,8 @@ class Generator(Command):
 
         :raises GeneratorError: If the `NAME` attribute is not defined.
         """
+        self.app: Application | None = None
+
         if not self.NAME:
             raise GeneratorError("Generator name must be defined.")
 
@@ -92,6 +95,10 @@ class Generator(Command):
     @property
     def templates_path(self) -> Path:
         return Path(__file__).parent / 'generators' / 'templates'
+
+    def invoke(self, ctx):
+        self.app = ctx.obj.get("app")
+        return super().invoke(ctx)
 
     def generate(self, *args, **kwargs):
         """Generates template.

--- a/grace/generator.py
+++ b/grace/generator.py
@@ -22,6 +22,9 @@ def generator() -> Generator:
 ```
 
 """
+import inflect
+
+
 from click import Command, Group
 from pathlib import Path
 from grace.importer import import_package_modules
@@ -144,6 +147,7 @@ class Generator(Command):
         )
 
         env.filters['camel_case_to_space'] = _camel_case_to_space
+        env.filters['pluralize'] = lambda w: inflect.engine().plural(w)
 
         if not env.list_templates():
             raise NoTemplateError(f"No templates found in {template_dir}")

--- a/grace/generator.py
+++ b/grace/generator.py
@@ -28,6 +28,7 @@ from grace.importer import import_package_modules
 from grace.exceptions import GeneratorError, ValidationError, NoTemplateError
 from cookiecutter.main import cookiecutter
 from jinja2 import Environment, PackageLoader, Template
+from typing import Any
 
 
 def register_generators(command_group: Group):
@@ -69,7 +70,7 @@ class Generator(Command):
     - `NAME`: The name of the generator command (must be defined by subclasses).
     - `OPTIONS`: A dictionary of additional Click options for the command.
     """
-    NAME: str = None
+    NAME: str | None = None
     OPTIONS: dict = {
 
     }
@@ -108,14 +109,14 @@ class Generator(Command):
         """Validates the arguments passed to the command."""
         return True
 
-    def generate_template(self, template_dir: str, variables: dict[str, any] = {}):
+    def generate_template(self, template_dir: str, variables: dict[str, Any] = {}):
         """Generates a template using Cookiecutter.
 
         :param template_dir: The name of the template to generate.
         :type template_dir: str
 
         :param variables: The variables to pass to the template. (default is {})
-        :type variables: dict[str, any]
+        :type variables: dict[str, Any]
         """
         template = str(self.templates_path / template_dir)
         cookiecutter(template, extra_context=variables, no_input=True)
@@ -123,7 +124,7 @@ class Generator(Command):
     def generate_file(
         self,
         template_dir: str,
-        variables: dict[str, any] = {},
+        variables: dict[str, Any] = {},
         output_dir: str = ""
     ):
         """Generate a module using jinja2 template.
@@ -132,13 +133,13 @@ class Generator(Command):
         :type template_dir: str
 
         :param variables: The variables to pass to the template. (default is {})
-        :type variables: dict[str, any]
+        :type variables: dict[str, Any]
 
         :param output_dir: The output directory for the generated template. (default is None)
         :type output_dir: str
         """
         env = Environment(
-            loader=PackageLoader("grace", self.templates_path / template_dir),
+            loader=PackageLoader('grace', str(self.templates_path / template_dir)),
             extensions=['jinja2_strcase.StrcaseExtension']
         )
 

--- a/grace/generators/migration_generator.py
+++ b/grace/generators/migration_generator.py
@@ -1,0 +1,40 @@
+from grace.generator import Generator
+from click.core import Argument
+from logging import info
+from grace.database import generate_migration
+
+
+class MigrationGenerator(Generator):
+    NAME: str = 'migration'
+    OPTIONS: dict = {
+        "params": [
+            Argument(["message"], type=str),
+        ],
+    }
+
+    def generate(self, message: str):
+        """Generates a new Alembic migration using autogenerate.
+
+        Example:
+        ```bash
+        grace generate migration "Add Greeting model"
+        ```
+        """
+        info(f"Generating migration '{message}'")
+        generate_migration(self.app, message)
+
+    def validate(self, message: str, **_kwargs) -> bool:
+        """
+        Validate the migration message.
+
+        The message must be a non-empty string.
+
+        Example:
+        - AddUserModel
+        - add_email_to_users
+        """
+        return bool(message.strip())
+
+
+def generator() -> Generator:
+    return MigrationGenerator()

--- a/grace/generators/model_generator.py
+++ b/grace/generators/model_generator.py
@@ -1,0 +1,60 @@
+from grace.generator import Generator
+from re import match
+from logging import info
+from click.core import Argument
+
+
+class ModelGenerator(Generator):
+    NAME: str = 'model'
+    OPTIONS: dict = {
+        "params": [
+            Argument(["name"], type=str),
+            Argument(["params"], type=str, nargs=-1)
+        ],
+    }
+
+    def generate(self, name: str, params: tuple[str]):
+        info(f"Creating model '{name}'")
+
+        columns, types = self.extract_columns(params)
+        model_columns = map(lambda c: f"{c[0]} = Column({c[1]})", columns)
+
+        self.generate_file(
+            self.NAME,
+            variables={
+                "model_name": name,
+                "model_columns": model_columns,
+                "model_column_types": types
+            },
+            output_dir="bot/models"
+        )
+
+    def validate(self, name: str, **_kwargs) -> bool:
+        """Validate the cog name.
+
+        A valid project name must be 'PascalCase' and contain only
+        - letters [Aa - Zz]
+        - numbers [0-9]
+
+        Example:
+        - HelloWorld
+        """
+        return bool(match(r'^[A-Z][a-zA-Z0-9]*$', name))
+
+    def extract_columns(self, params: tuple[str]) -> tuple[list, list]:
+        columns = []
+        types = []
+
+        for param in params:
+            name, type = param.split(':')
+
+            if type not in types and type != 'Integer':
+                types.append(type)
+
+            columns.append((name, type))
+
+        return columns, types
+
+
+def generator() -> Generator:
+    return ModelGenerator()

--- a/grace/generators/model_generator.py
+++ b/grace/generators/model_generator.py
@@ -14,7 +14,21 @@ class ModelGenerator(Generator):
     }
 
     def generate(self, name: str, params: tuple[str]):
-        info(f"Creating model '{name}'")
+        """Generate a new model file along its migration.
+
+        The model will be created in the `bot/models` directory with
+        a SQLAlchemy-style definition. You can specify column names and types
+        during generation using the format `column_name:Type`.
+
+        Supported types are any valid SQLAlchemy column types (e.g., `String`, `Integer`,
+        `Boolean`, etc.). See https://docs.sqlalchemy.org/en/20/core/types.html
+
+        Example:
+        ```bash
+        grace generate model Greeting message:String lang:String
+        ```
+        """
+        info(f"Generating model '{name}'")
 
         columns, types = self.extract_columns(params)
         model_columns = map(lambda c: f"{c[0]} = Column({c[1]})", columns)
@@ -29,26 +43,30 @@ class ModelGenerator(Generator):
             output_dir="bot/models"
         )
 
+        generate_migration(self.app, f"Create {name}")
+
     def validate(self, name: str, **_kwargs) -> bool:
-        """Validate the cog name.
+        """Validate the model name.
 
-        A valid project name must be 'PascalCase' and contain only
-        - letters [Aa - Zz]
-        - numbers [0-9]
+        A valid model name must:
+        - Start with an uppercase letter.
+        - Contain only letters (A-Z, a-z) and numbers (0-9).
 
-        Example:
+        Examples of valid names:
         - HelloWorld
+        - User123
+        - ProductItem
         """
         return bool(match(r'^[A-Z][a-zA-Z0-9]*$', name))
 
     def extract_columns(self, params: tuple[str]) -> tuple[list, list]:
         columns = []
-        types = []
+        types = ['Integer']
 
         for param in params:
             name, type = param.split(':')
 
-            if type not in types and type != 'Integer':
+            if type not in types:
                 types.append(type)
 
             columns.append((name, type))

--- a/grace/generators/model_generator.py
+++ b/grace/generators/model_generator.py
@@ -2,6 +2,7 @@ from grace.generator import Generator
 from re import match
 from logging import info
 from click.core import Argument
+from grace.generators.migration_generator import generate_migration
 
 
 class ModelGenerator(Generator):

--- a/grace/generators/templates/model/{{ model_name | to_snake }}.py
+++ b/grace/generators/templates/model/{{ model_name | to_snake }}.py
@@ -1,0 +1,9 @@
+from sqlalchemy import Column, Integer{{ ", {}".format(','.join(model_column_types)) }}
+from bot import app
+from grace.model import Model
+
+class {{ model_name | to_camel }}(app.base, Model):
+    __tablename__ = "{{ model_name | to_snake | pluralize }}"
+
+    id = Column(Integer, primary_key=True)
+    {{ model_columns | join('\n    ') }}

--- a/grace/generators/templates/model/{{ model_name | to_snake }}.py
+++ b/grace/generators/templates/model/{{ model_name | to_snake }}.py
@@ -2,6 +2,7 @@ from sqlalchemy import Column, Integer{{ ", {}".format(','.join(model_column_typ
 from bot import app
 from grace.model import Model
 
+
 class {{ model_name | to_camel }}(app.base, Model):
     __tablename__ = "{{ model_name | to_snake | pluralize }}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 	"alembic==1.8.1",
 	"cookiecutter",
 	"jinja2-strcase",
-	"jinja2_pluralize",
+	"inflect",
 	"mypy",
 	"pytest",
 	"flake8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
 	"alembic==1.8.1",
 	"cookiecutter",
 	"jinja2-strcase",
+	"jinja2_pluralize",
 	"mypy",
 	"pytest",
 	"flake8",
@@ -43,3 +44,7 @@ packages = ["grace"]
 
 [tool.mypy]
 exclude = ['grace/generators/templates']
+
+[[tool.mypy.overrides]]
+module = ["jinja2_pluralize.*", "cookiecutter.*"]
+follow_untyped_imports = true


### PR DESCRIPTION
This PR introduces a generator for models and migrations, along with additional commands for managing database migrations.

New commands include:
- `generate model NAME [column_name:Type, ...]` – Generates a model with the specified columns and their types. The migration is automatically generated as well.
- `generate migration MESSAGE` – Generates a new migration.
- `db up [REVISION]` – Applies database migrations up to the specified revision.
- `db down [REVISION]` – Reverts database migrations to the specified revision.

Note: The `generate model` command will automatically generate a migration.
